### PR TITLE
Terminal formatting

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -44,36 +44,7 @@ impl Terminal {
 
     pub fn write(&mut self, message: String) {
         write!(self.terminal, "{}", message).unwrap();
-    }
-
-    pub fn write_background(&mut self, pos: Position, message: String, color: &AnsiValue) {
-        self.restore_cursor_write(pos, format!("{}{}", color::Bg(*color), message));
-    }
-
-    pub fn draw_large_box(&mut self, start: Position, end: Position, color: &AnsiValue) {
-        if start.get_x() <= end.get_x() && start.get_y() <= end.get_y() {
-            let mut format = Formatter::new().bg_color(color);
-            let mut cursor = Position::new_origin();
-            for y in start.get_y()..=end.get_y() {
-                cursor.set(start.get_x(), y);
-                format += &Formatter::new()
-                .go_to(cursor)
-                .text(format!("{:width$}", " ", width = (end.get_x() - start.get_x() + 1).into()));
-            }
-            self.write_format(format);
-        }
-    }
-
-    pub fn restore_cursor_write(&mut self, pos: Position, message: String) {
-        if pos.is_in_boundary() {
-            self.write(format!(
-                "{}{}{}",
-                cursor::Save,
-                cursor::Goto(pos.get_x(), pos.get_y()),
-                message
-            ));
-            self.write(cursor::Restore.to_string());
-        }
+        self.terminal.flush().unwrap();
     }
 
     pub fn clear_all(&mut self) {
@@ -83,10 +54,6 @@ impl Terminal {
     pub fn reset(&mut self) {
         self.write(format!("{}{}{}{}", cursor::Goto::default(), color::Bg(color::Reset), color::Fg(color::Reset), style::Reset));
         self.clear_all();
-    }
-
-    pub fn flush(&mut self) {
-        self.terminal.flush().unwrap();
     }
 
     pub fn begin(&mut self) {
@@ -109,6 +76,7 @@ impl Terminal {
     }
 
     pub fn write_format(&mut self, format: Formatter) {
+        if format.string.is_empty() { return; }
         self.write(format.string);
     }
 }
@@ -153,6 +121,20 @@ impl Formatter {
 
     pub fn text(mut self, text: String) -> Self {
         self.string += text.as_str();
+        self
+    }
+
+    pub fn create_box(mut self, start: &Position, end: &Position, color: &AnsiValue) -> Self {
+        self = self.bg_color(color);
+        if start.get_x() <= end.get_x() && start.get_y() <= end.get_y() {
+            let mut cursor = Position::new_origin();
+            for y in start.get_y()..=end.get_y() {
+                cursor.set(start.get_x(), y);
+                self += &Formatter::new()
+                .go_to(cursor)
+                .text(format!("{:width$}", " ", width = (end.get_x() - start.get_x() + 1).into()));
+            }
+        }
         self
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -105,22 +105,22 @@ impl Formatter {
     }
 
     pub fn bg_color(mut self, color: &AnsiValue) -> Self {
-        self.string += color::Bg(*color).to_string().as_str();
+        self.string += &color::Bg(*color).to_string();
         self
     }
 
     pub fn fg_color(mut self, color: &AnsiValue) -> Self {
-        self.string += color::Fg(*color).to_string().as_str();
+        self.string += &color::Fg(*color).to_string();
         self
     }
 
     pub fn go_to(mut self, position: Position) -> Self {
-        self.string += cursor::Goto(position.get_x(), position.get_y()).to_string().as_str();
+        self.string += &cursor::Goto(position.get_x(), position.get_y()).to_string();
         self
     }
 
     pub fn text(mut self, text: String) -> Self {
-        self.string += text.as_str();
+        self.string += &text;
         self
     }
 


### PR DESCRIPTION
Add optimizations to code when writing to the terminal.
Before the writing would occur multiple times we attempt to draw a calendar (up to 40)
This was very slow and could be seen by a user.
Now I format it and add those drawing formats and finally write it all at once.
This has shown great improvements

This branch also includes a couple of optimizations for multi threading by using channels instead of a mutex lock.